### PR TITLE
Add 12 end-to-end test scenarios for altium-cli full design flow

### DIFF
--- a/scenarios/01-single-resistor.md
+++ b/scenarios/01-single-resistor.md
@@ -1,0 +1,363 @@
+# Scenario 01 — Single Resistor
+
+Bare-minimum end-to-end: one 10k 0402 resistor from part lookup through PCB
+import. Tests that the pipeline works at all.
+
+**Parts:** 1 (R1: 10k 0402)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1: Look up resistor specs
+
+```
+RUN: datasheet-cli search "10k ohm 0402 1%"
+ASSERT: exit 0
+ASSERT: stdout contains "0402"
+ASSERT: stdout contains "10k" or "10000"
+```
+
+### Step 1.2: Confirm package dimensions
+
+```
+RUN: datasheet-cli specs "RC0402FR-0710KL" --fields package,tolerance,power-rating
+ASSERT: exit 0
+ASSERT: stdout contains "0402"
+```
+
+**Record:** R1 = 10k, 0402, 1%, 1/16W
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create SchLib
+
+```
+RUN: altium-cli schlib create work/scenario-01/parts.SchLib
+ASSERT: exit 0
+ASSERT: stdout contains "Created new SchLib"
+ASSERT: file exists work/scenario-01/parts.SchLib
+```
+
+### Step 2.2: Add resistor symbol
+
+```
+RUN: altium-cli schlib add-component work/scenario-01/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+ASSERT: stdout contains "Added component"
+```
+
+### Step 2.3: Add pin 1
+
+```
+RUN: altium-cli schlib add-pin work/scenario-01/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+ASSERT: stdout contains "Added pin"
+```
+
+### Step 2.4: Add pin 2
+
+```
+RUN: altium-cli schlib add-pin work/scenario-01/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+ASSERT: stdout contains "Added pin"
+```
+
+### Step 2.5: Add body rectangle
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-01/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+ASSERT: stdout contains "Added rectangle"
+```
+
+### Step 2.6: Verify symbol
+
+```
+RUN: altium-cli schlib component work/scenario-01/parts.SchLib RES --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 2
+ASSERT: json .name == "RES"
+```
+
+### Step 2.7: Verify pin details
+
+```
+RUN: altium-cli schlib pins work/scenario-01/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .total_pins == 2
+```
+
+---
+
+## Phase 3 — PCB Footprint Library
+
+### Step 3.1: Create PcbLib
+
+```
+RUN: altium-cli pcblib create work/scenario-01/fps.PcbLib
+ASSERT: exit 0
+ASSERT: stdout contains "Created new"
+ASSERT: file exists work/scenario-01/fps.PcbLib
+```
+
+### Step 3.2: Generate 0402 chip footprint
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-01/fps.PcbLib R0402 --size 0402
+ASSERT: exit 0
+ASSERT: stdout contains "Added" or stdout contains "Generated"
+```
+
+### Step 3.3: Verify footprint exists
+
+```
+RUN: altium-cli pcblib footprint work/scenario-01/fps.PcbLib R0402 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 2
+ASSERT: json .pattern == "R0402"
+```
+
+### Step 3.4: Verify pad dimensions are in 0402 range
+
+```
+RUN: altium-cli pcblib measure work/scenario-01/fps.PcbLib R0402 --json
+ASSERT: exit 0
+ASSERT: json .dimensions.width.mils > 20
+ASSERT: json .dimensions.width.mils < 80
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-01/fps.PcbLib` in Altium → footprint R0402.
+**Check:** Two rectangular pads, roughly 1mm apart, with silkscreen outline.
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create schematic
+
+```
+RUN: altium-cli schdoc create work/scenario-01/design.SchDoc
+ASSERT: exit 0
+ASSERT: stdout contains "Created new schematic"
+ASSERT: file exists work/scenario-01/design.SchDoc
+```
+
+### Step 4.2: Place resistor
+
+```
+RUN: altium-cli edit work/scenario-01/design.SchDoc -c "add-component work/scenario-01/parts.SchLib RES 1000 1000 R1"
+ASSERT: exit 0
+ASSERT: stdout contains "Success" or stdout contains "Added"
+```
+
+### Step 4.3: Verify component placed
+
+```
+RUN: altium-cli schdoc components work/scenario-01/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 1
+```
+
+### Step 4.4: Add power ports for test connectivity
+
+```
+RUN: altium-cli edit work/scenario-01/design.SchDoc -c "add-net-label NET1 950 1000"
+ASSERT: exit 0
+```
+
+### Step 4.5: Add second net label
+
+```
+RUN: altium-cli edit work/scenario-01/design.SchDoc -c "add-net-label NET2 1050 1000"
+ASSERT: exit 0
+```
+
+### Step 4.6: Route pin 1 to NET1
+
+```
+RUN: altium-cli edit work/scenario-01/design.SchDoc -c "route R1.1 %NET1"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+### Step 4.7: Route pin 2 to NET2
+
+```
+RUN: altium-cli edit work/scenario-01/design.SchDoc -c "route R1.2 %NET2"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1: Validate schematic
+
+```
+RUN: altium-cli edit work/scenario-01/design.SchDoc -c "validate"
+ASSERT: exit 0
+ASSERT: stdout contains "Success" or json .is_valid == true
+```
+
+### Step 5.2: Check netlist
+
+```
+RUN: altium-cli schdoc netlist work/scenario-01/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_nets >= 2
+```
+
+### Step 5.3: Check BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-01/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 1
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-01/design.SchDoc` in Altium.
+**Check:** Single resistor symbol R1 with wires to NET1 and NET2 labels.
+
+---
+
+## Phase 6 — Project Setup
+
+### Step 6.1: Create project
+
+```
+RUN: altium-cli prjpcb create work/scenario-01/project.PrjPcb --name "Single Resistor"
+ASSERT: exit 0
+ASSERT: stdout contains "Created project"
+```
+
+### Step 6.2: Add schematic
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-01/project.PrjPcb work/scenario-01/design.SchDoc
+ASSERT: exit 0
+ASSERT: stdout contains "Added document"
+```
+
+### Step 6.3: Add libraries
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-01/project.PrjPcb work/scenario-01/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-01/project.PrjPcb work/scenario-01/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 6.4: Verify project
+
+```
+RUN: altium-cli prjpcb overview work/scenario-01/project.PrjPcb --json
+ASSERT: exit 0
+ASSERT: json .document_summary.total_documents >= 3
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1: Create PCB
+
+```
+RUN: altium-cli pcbdoc create work/scenario-01/board.PcbDoc
+ASSERT: exit 0
+ASSERT: stdout contains "Created new PCB"
+ASSERT: file exists work/scenario-01/board.PcbDoc
+```
+
+### Step 7.2: Set board outline (10mm x 10mm = 394 x 394 mil)
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-01/board.PcbDoc 394 394
+ASSERT: exit 0
+ASSERT: stdout contains "outline"
+```
+
+### Step 7.3: Add clearance rule
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-01/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.4: Add min track width rule
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-01/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.5: Verify board setup
+
+```
+RUN: altium-cli pcbdoc outline work/scenario-01/board.PcbDoc --json
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc rules work/scenario-01/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json .total_rules >= 2
+```
+
+### Step 7.6: Add PCB to project
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-01/project.PrjPcb work/scenario-01/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import to PCB
+
+### Step 8.1: Dry-run import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-01/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "R1"
+```
+
+### Step 8.2: Execute import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-01/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.3: Verify component on PCB
+
+```
+RUN: altium-cli pcbdoc components work/scenario-01/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "R1"
+```
+
+### Step 8.4: Verify nets on PCB
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-01/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "NET1"
+ASSERT: json output includes net "NET2"
+```
+
+### MANUAL CHECKPOINT C
+
+Open `work/scenario-01/board.PcbDoc` in Altium.
+**Check:** One 0402 footprint (R1) present, two ratsnest lines visible.

--- a/scenarios/02-led-resistor.md
+++ b/scenarios/02-led-resistor.md
@@ -1,0 +1,403 @@
+# Scenario 02 — LED + Current-Limiting Resistor
+
+Two-component circuit with a direct wire between them. Tests `route` between
+component pins and mixed footprint types (0402 resistor + 0805 LED).
+
+**Parts:** 2 (R1: 330R 0402, D1: red LED 0805)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "red LED 0805 SMD"
+ASSERT: exit 0
+ASSERT: stdout contains "0805"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli specs "red LED 0805" --fields forward-voltage,forward-current
+ASSERT: exit 0
+ASSERT: stdout contains "forward-voltage" or stdout contains "Vf"
+```
+
+**Record:** D1 = red LED 0805, Vf~2.0V, If~20mA. R1 = 330R 0402 → (3.3V-2.0V)/330 = 3.9mA.
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create library
+
+```
+RUN: altium-cli schlib create work/scenario-02/parts.SchLib
+ASSERT: exit 0
+ASSERT: file exists work/scenario-02/parts.SchLib
+```
+
+### Step 2.2: Add resistor symbol with pins and body
+
+```
+RUN: altium-cli schlib add-component work/scenario-02/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-02/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-02/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-02/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+### Step 2.3: Add LED symbol with pins and body
+
+```
+RUN: altium-cli schlib add-component work/scenario-02/parts.SchLib LED --description "LED"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-02/parts.SchLib LED A "Anode" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-02/parts.SchLib LED K "Cathode" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-02/parts.SchLib LED -30 -20 30 20
+ASSERT: exit 0
+```
+
+### Step 2.4: Verify library has 2 components
+
+```
+RUN: altium-cli schlib info work/scenario-02/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 2
+```
+
+### Step 2.5: Verify resistor pins
+
+```
+RUN: altium-cli schlib component work/scenario-02/parts.SchLib RES --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 2
+```
+
+### Step 2.6: Verify LED pins
+
+```
+RUN: altium-cli schlib component work/scenario-02/parts.SchLib LED --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 2
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create PcbLib
+
+```
+RUN: altium-cli pcblib create work/scenario-02/fps.PcbLib
+ASSERT: exit 0
+ASSERT: file exists work/scenario-02/fps.PcbLib
+```
+
+### Step 3.2: Generate 0402 for resistor
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-02/fps.PcbLib R0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.3: Generate 0805 for LED
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-02/fps.PcbLib LED0805 --size 0805
+ASSERT: exit 0
+```
+
+### Step 3.4: Verify both footprints exist
+
+```
+RUN: altium-cli pcblib list work/scenario-02/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 2
+```
+
+### Step 3.5: Verify 0402 has 2 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-02/fps.PcbLib R0402 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 2
+```
+
+### Step 3.6: Verify 0805 has 2 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-02/fps.PcbLib LED0805 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 2
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-02/fps.PcbLib` in Altium.
+**Check:** R0402 pads are visibly smaller than LED0805 pads.
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create schematic
+
+```
+RUN: altium-cli schdoc create work/scenario-02/design.SchDoc
+ASSERT: exit 0
+ASSERT: file exists work/scenario-02/design.SchDoc
+```
+
+### Step 4.2: Place resistor at (800, 1000)
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "add-component work/scenario-02/parts.SchLib RES 800 1000 R1"
+ASSERT: exit 0
+ASSERT: stdout contains "Success" or stdout contains "Added"
+```
+
+### Step 4.3: Place LED at (1200, 1000)
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "add-component work/scenario-02/parts.SchLib LED 1200 1000 D1"
+ASSERT: exit 0
+```
+
+### Step 4.4: Verify 2 components placed
+
+```
+RUN: altium-cli schdoc components work/scenario-02/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 2
+```
+
+### Step 4.5: Add VCC power port above R1
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "add-power VCC 800 1200 bar down"
+ASSERT: exit 0
+```
+
+### Step 4.6: Add GND power port below D1
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire VCC → R1 pin 1
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "route @VCC R1.1"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+### Step 4.8: Wire R1 pin 2 → D1 Anode (direct wire between components)
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "route R1.2 D1.A"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+### Step 4.9: Wire D1 Cathode → GND
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "route D1.K @GND"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+### Step 4.10: Verify wire count
+
+```
+RUN: altium-cli schdoc wires work/scenario-02/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_wires >= 3
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1: Validate
+
+```
+RUN: altium-cli edit work/scenario-02/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Check netlist — should have VCC, GND, and the R1-D1 junction net
+
+```
+RUN: altium-cli schdoc netlist work/scenario-02/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_nets >= 2
+```
+
+### Step 5.3: Check BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-02/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 2
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-02/design.SchDoc` in Altium.
+**Check:** R1 and D1 connected in series between VCC and GND, with a visible wire from R1.2 to D1.A.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1: Create project
+
+```
+RUN: altium-cli prjpcb create work/scenario-02/project.PrjPcb --name "LED Circuit"
+ASSERT: exit 0
+```
+
+### Step 6.2: Add all documents
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-02/project.PrjPcb work/scenario-02/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-02/project.PrjPcb work/scenario-02/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-02/project.PrjPcb work/scenario-02/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 6.3: Verify project has all docs
+
+```
+RUN: altium-cli prjpcb documents work/scenario-02/project.PrjPcb --json
+ASSERT: exit 0
+ASSERT: json .total_documents >= 3
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1: Create PCB
+
+```
+RUN: altium-cli pcbdoc create work/scenario-02/board.PcbDoc
+ASSERT: exit 0
+ASSERT: file exists work/scenario-02/board.PcbDoc
+```
+
+### Step 7.2: Set board outline (15mm x 10mm = 591 x 394 mil)
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-02/board.PcbDoc 591 394
+ASSERT: exit 0
+```
+
+### Step 7.3: Set grid and track settings
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-02/board.PcbDoc --imperial --grid-size 25 --track-width 10
+ASSERT: exit 0
+```
+
+### Step 7.4: Add clearance rule
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-02/board.PcbDoc "Clearance" --value 8
+ASSERT: exit 0
+```
+
+### Step 7.5: Verify rules
+
+```
+RUN: altium-cli pcbdoc rules work/scenario-02/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json .total_rules >= 1
+```
+
+### Step 7.6: Add PCB to project
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-02/project.PrjPcb work/scenario-02/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import to PCB
+
+### Step 8.1: Dry-run
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-02/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "R1"
+ASSERT: stdout contains "D1"
+```
+
+### Step 8.2: Execute import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-02/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.3: Verify components on PCB
+
+```
+RUN: altium-cli pcbdoc components work/scenario-02/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "D1"
+```
+
+### Step 8.4: Verify nets on PCB
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-02/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "VCC"
+ASSERT: json output includes net "GND"
+```
+
+### MANUAL CHECKPOINT C
+
+Open `work/scenario-02/board.PcbDoc` in Altium.
+**Check:** R1 has smaller 0402 pads, D1 has larger 0805 pads. Ratsnest connects them.

--- a/scenarios/03-mcu-power.md
+++ b/scenarios/03-mcu-power.md
@@ -1,0 +1,419 @@
+# Scenario 03 — MCU Power-On (IC + Bypass Cap)
+
+An 8-pin IC generated with `gen-ic` plus a bypass capacitor connected via
+VCC/GND power ports. Tests IC symbol generation, power port wiring, and
+SOIC-8 footprint creation.
+
+**Parts:** 2 (U1: ATtiny85 SOIC-8, C1: 100nF 0402)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "ATtiny85" --package SOIC-8
+ASSERT: exit 0
+ASSERT: stdout contains "ATtiny85"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "ATtiny85-20SU"
+ASSERT: exit 0
+ASSERT: stdout contains "VCC"
+ASSERT: stdout contains "GND"
+```
+
+**Record:** U1 = ATtiny85, SOIC-8. Pins: PB5(1), PB3(2), PB4(3), GND(4), PB0(5), PB1(6), PB2(7), VCC(8). C1 = 100nF 0402 between VCC and GND.
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create library
+
+```
+RUN: altium-cli schlib create work/scenario-03/parts.SchLib
+ASSERT: exit 0
+ASSERT: file exists work/scenario-03/parts.SchLib
+```
+
+### Step 2.2: Generate ATtiny85 IC symbol with gen-ic
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-03/parts.SchLib ATtiny85 --pins "PB5,PB3,PB4,GND,PB0,PB1,PB2,VCC" --description "8-bit AVR MCU"
+ASSERT: exit 0
+ASSERT: stdout contains "Generated IC symbol"
+```
+
+### Step 2.3: Verify IC has 8 pins
+
+```
+RUN: altium-cli schlib component work/scenario-03/parts.SchLib ATtiny85 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 8
+ASSERT: json .description == "8-bit AVR MCU"
+```
+
+### Step 2.4: Verify all pin names present
+
+```
+RUN: altium-cli schlib pins work/scenario-03/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .total_pins == 8
+```
+
+### Step 2.5: Add capacitor symbol
+
+```
+RUN: altium-cli schlib add-component work/scenario-03/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-03/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-03/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-03/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-03/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+### Step 2.6: Verify library has 2 components
+
+```
+RUN: altium-cli schlib info work/scenario-03/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 2
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-03/parts.SchLib` in Altium → ATtiny85.
+**Check:** Rectangle body with 4 pins per side, pin names readable.
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create PcbLib
+
+```
+RUN: altium-cli pcblib create work/scenario-03/fps.PcbLib
+ASSERT: exit 0
+ASSERT: file exists work/scenario-03/fps.PcbLib
+```
+
+### Step 3.2: Create SOIC-8 footprint with dual-row pads
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-03/fps.PcbLib SOIC-8 --description "SOIC-8 150mil body"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-03/fps.PcbLib SOIC-8 8 --pitch 50 --span 244
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify SOIC-8 has 8 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-03/fps.PcbLib SOIC-8 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 8
+```
+
+### Step 3.4: Verify pitch is ~50 mil
+
+```
+RUN: altium-cli pcblib measure work/scenario-03/fps.PcbLib SOIC-8 --json
+ASSERT: exit 0
+ASSERT: json .pitch[0].pitch.mils >= 45
+ASSERT: json .pitch[0].pitch.mils <= 55
+```
+
+### Step 3.5: Generate 0402 for bypass cap
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-03/fps.PcbLib C0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.6: Verify 0402 footprint
+
+```
+RUN: altium-cli pcblib footprint work/scenario-03/fps.PcbLib C0402 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 2
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-03/fps.PcbLib` in Altium → SOIC-8.
+**Check:** 8 pads in two rows of 4, pin 1 marker visible.
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create schematic
+
+```
+RUN: altium-cli schdoc create work/scenario-03/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place MCU
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "add-component work/scenario-03/parts.SchLib ATtiny85 1000 1500 U1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Place bypass cap near MCU
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "add-component work/scenario-03/parts.SchLib CAP 700 1200 C1"
+ASSERT: exit 0
+```
+
+### Step 4.4: Verify 2 components
+
+```
+RUN: altium-cli schdoc components work/scenario-03/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 2
+```
+
+### Step 4.5: Add VCC power port
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "add-power VCC 1000 2000 bar down"
+ASSERT: exit 0
+```
+
+### Step 4.6: Add GND power port
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "add-power GND 1000 800 ground up"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire U1.VCC to VCC rail
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "route U1.VCC @VCC"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+### Step 4.8: Wire U1.GND to GND rail
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+ASSERT: stdout contains "Success"
+```
+
+### Step 4.9: Wire bypass cap pin 1 to VCC
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "route C1.1 @VCC"
+ASSERT: exit 0
+```
+
+### Step 4.10: Wire bypass cap pin 2 to GND
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "route C1.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.11: Add junctions
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1: Validate — expect warnings for unconnected PB0-PB5 (no load)
+
+```
+RUN: altium-cli edit work/scenario-03/design.SchDoc -c "validate"
+ASSERT: exit 0 or exit 1
+```
+
+*Note:* PB0-PB5 are intentionally unconnected. If validate reports warnings for
+floating pins, that is expected and correct.
+
+### Step 5.2: Check netlist has VCC and GND
+
+```
+RUN: altium-cli schdoc netlist work/scenario-03/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net name containing "VCC"
+ASSERT: json output includes net name containing "GND"
+```
+
+### Step 5.3: Verify VCC net connects U1.VCC and C1.1
+
+```
+RUN: altium-cli schdoc netlist work/scenario-03/design.SchDoc --filter VCC --json
+ASSERT: exit 0
+ASSERT: json output includes pin "U1.VCC" or "U1:VCC"
+ASSERT: json output includes pin "C1.1" or "C1:1"
+```
+
+### Step 5.4: Check BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-03/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 2
+```
+
+### Step 5.5: Check power map
+
+```
+RUN: altium-cli schdoc power-map work/scenario-03/design.SchDoc --json
+ASSERT: exit 0
+```
+
+### MANUAL CHECKPOINT C
+
+Open `work/scenario-03/design.SchDoc` in Altium.
+**Check:** U1 (ATtiny85) has VCC and GND wired to power ports, C1 bridges VCC-GND.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1: Create project
+
+```
+RUN: altium-cli prjpcb create work/scenario-03/project.PrjPcb --name "MCU Power"
+ASSERT: exit 0
+```
+
+### Step 6.2: Add documents
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-03/project.PrjPcb work/scenario-03/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-03/project.PrjPcb work/scenario-03/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-03/project.PrjPcb work/scenario-03/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1: Create PCB
+
+```
+RUN: altium-cli pcbdoc create work/scenario-03/board.PcbDoc
+ASSERT: exit 0
+```
+
+### Step 7.2: Board outline 15mm x 15mm (591 x 591 mil)
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-03/board.PcbDoc 591 591
+ASSERT: exit 0
+```
+
+### Step 7.3: Settings
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-03/board.PcbDoc --imperial --grid-size 25 --track-width 10
+ASSERT: exit 0
+```
+
+### Step 7.4: Rules
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-03/board.PcbDoc "Clearance" --value 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-03/board.PcbDoc "MinTrackWidth" --value 8
+ASSERT: exit 0
+```
+
+### Step 7.5: Add to project
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-03/project.PrjPcb work/scenario-03/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1: Dry-run
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-03/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "C1"
+```
+
+### Step 8.2: Import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-03/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.3: Verify 2 components on PCB
+
+```
+RUN: altium-cli pcbdoc components work/scenario-03/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "C1"
+```
+
+### Step 8.4: Verify VCC and GND nets on PCB
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-03/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "VCC"
+ASSERT: json output includes net "GND"
+```
+
+### MANUAL CHECKPOINT D
+
+Open `work/scenario-03/board.PcbDoc` in Altium.
+**Check:** U1 is SOIC-8 (8 pads, two rows), C1 is 0402 (2 small pads). Ratsnest shows VCC/GND connections.

--- a/scenarios/04-voltage-divider.md
+++ b/scenarios/04-voltage-divider.md
@@ -1,0 +1,354 @@
+# Scenario 04 — Voltage Divider
+
+Three resistors forming a voltage divider with named net labels for VIN, VMID,
+and GND. Tests net-label-based connectivity (no direct wires between components),
+multiple named nets, and netlist verification of the tap point.
+
+**Parts:** 3 (R1: 10k, R2: 10k, R3: 10k — three equal resistors for 1/3 and 2/3 taps)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "10k ohm 0402 1%"
+ASSERT: exit 0
+```
+
+**Record:** R1=R2=R3 = 10k 0402. VMID1 = VIN × R2R3/(R1+R2+R3), VMID2 = VIN × R3/(R1+R2+R3).
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create library
+
+```
+RUN: altium-cli schlib create work/scenario-04/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Add resistor symbol
+
+```
+RUN: altium-cli schlib add-component work/scenario-04/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-04/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-04/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-04/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify
+
+```
+RUN: altium-cli schlib component work/scenario-04/parts.SchLib RES --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 2
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create and generate 0402
+
+```
+RUN: altium-cli pcblib create work/scenario-04/fps.PcbLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-04/fps.PcbLib R0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.2: Verify
+
+```
+RUN: altium-cli pcblib footprint work/scenario-04/fps.PcbLib R0402 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 2
+```
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create schematic
+
+```
+RUN: altium-cli schdoc create work/scenario-04/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place three resistors vertically stacked
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-component work/scenario-04/parts.SchLib RES 1000 1800 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-component work/scenario-04/parts.SchLib RES 1000 1400 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-component work/scenario-04/parts.SchLib RES 1000 1000 R3"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 3 components
+
+```
+RUN: altium-cli schdoc components work/scenario-04/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 3
+```
+
+### Step 4.4: Add net labels — VIN at top, VMID1 between R1-R2, VMID2 between R2-R3, GND at bottom
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-net-label VIN 1000 2000"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-net-label VMID1 1000 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-net-label VMID2 1000 1200"
+ASSERT: exit 0
+```
+
+### Step 4.5: Add GND power port at bottom
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-power GND 1000 800 ground up"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire R1 into VIN and VMID1 nets
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "route R1.1 %VIN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "route R1.2 %VMID1"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire R2 into VMID1 and VMID2 nets
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "route R2.1 %VMID1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "route R2.2 %VMID2"
+ASSERT: exit 0
+```
+
+### Step 4.8: Wire R3 into VMID2 and GND nets
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "route R3.1 %VMID2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "route R3.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.9: Add junctions where nets merge
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1: Validate
+
+```
+RUN: altium-cli edit work/scenario-04/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify 4 nets exist (VIN, VMID1, VMID2, GND)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-04/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_nets >= 4
+```
+
+### Step 5.3: Verify VMID1 net connects R1.2 and R2.1
+
+```
+RUN: altium-cli schdoc netlist work/scenario-04/design.SchDoc --filter VMID1 --json
+ASSERT: exit 0
+ASSERT: json net "VMID1" has >= 2 pins
+```
+
+### Step 5.4: Verify VMID2 net connects R2.2 and R3.1
+
+```
+RUN: altium-cli schdoc netlist work/scenario-04/design.SchDoc --filter VMID2 --json
+ASSERT: exit 0
+ASSERT: json net "VMID2" has >= 2 pins
+```
+
+### Step 5.5: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-04/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 3
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-04/design.SchDoc` in Altium.
+**Check:** Three resistors in a vertical chain. Net labels VIN, VMID1, VMID2 visible at each tap. GND power symbol at bottom.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1: Create project
+
+```
+RUN: altium-cli prjpcb create work/scenario-04/project.PrjPcb --name "Voltage Divider"
+ASSERT: exit 0
+```
+
+### Step 6.2: Add documents
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-04/project.PrjPcb work/scenario-04/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-04/project.PrjPcb work/scenario-04/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-04/project.PrjPcb work/scenario-04/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1: Create PCB (10mm x 15mm = 394 x 591 mil)
+
+```
+RUN: altium-cli pcbdoc create work/scenario-04/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-04/board.PcbDoc 394 591
+ASSERT: exit 0
+```
+
+### Step 7.2: Rules
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-04/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-04/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.3: Add to project
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-04/project.PrjPcb work/scenario-04/board.PcbDoc
+ASSERT: exit 0
+```
+
+### Step 7.4: Verify
+
+```
+RUN: altium-cli pcbdoc rules work/scenario-04/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json .total_rules >= 2
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1: Dry-run
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-04/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "R1"
+ASSERT: stdout contains "R2"
+ASSERT: stdout contains "R3"
+```
+
+### Step 8.2: Import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-04/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.3: Verify 3 components
+
+```
+RUN: altium-cli pcbdoc components work/scenario-04/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "R3"
+```
+
+### Step 8.4: Verify all 4 nets transferred
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-04/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "VIN"
+ASSERT: json output includes net "VMID1"
+ASSERT: json output includes net "VMID2"
+ASSERT: json output includes net "GND"
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-04/board.PcbDoc` in Altium.
+**Check:** Three identical 0402 footprints. Ratsnest shows chain connectivity (no isolated components).

--- a/scenarios/05-i2c-temp-sensor.md
+++ b/scenarios/05-i2c-temp-sensor.md
@@ -1,0 +1,525 @@
+# Scenario 05 — I2C Temperature Sensor Breakout
+
+Sensor IC + two I2C pull-up resistors + bypass cap + pin header. Tests `gen-ic`
+with 6 pins, I2C bus net labels (SDA/SCL shared across multiple components), and
+mixed footprints (WSON-6 + 0402 + through-hole header).
+
+**Parts:** 5 (U1: TMP117 WSON-6, R1: 4.7k SDA pull-up, R2: 4.7k SCL pull-up,
+C1: 100nF bypass, J1: 1x4 header)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "TMP117" --package WSON
+ASSERT: exit 0
+ASSERT: stdout contains "TMP117"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "TMP117AIDRVR"
+ASSERT: exit 0
+ASSERT: stdout contains "SDA"
+ASSERT: stdout contains "SCL"
+```
+
+**Record:** U1 = TMP117, WSON-6. Pins: SCL(1), GND(2), ALERT(3), ADD0(4), SDA(5), V+(6).
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-05/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate TMP117 symbol
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-05/parts.SchLib TMP117 --pins "SCL,GND,ALERT,ADD0,SDA,VDD" --description "I2C Temp Sensor"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify TMP117 has 6 pins
+
+```
+RUN: altium-cli schlib component work/scenario-05/parts.SchLib TMP117 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 6
+```
+
+### Step 2.4: Add resistor symbol
+
+```
+RUN: altium-cli schlib add-component work/scenario-05/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-05/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-05/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-05/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+### Step 2.5: Add capacitor symbol
+
+```
+RUN: altium-cli schlib add-component work/scenario-05/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-05/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-05/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-05/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-05/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+### Step 2.6: Generate 1x4 header symbol
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-05/parts.SchLib HDR4 --pins "VDD,GND,SDA,SCL" --description "1x4 Header"
+ASSERT: exit 0
+```
+
+### Step 2.7: Verify 4 components in library
+
+```
+RUN: altium-cli schlib info work/scenario-05/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 4
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-05/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: WSON-6 footprint (dual-row, 3 per side)
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-05/fps.PcbLib WSON-6 --description "WSON-6 2x2mm"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-05/fps.PcbLib WSON-6 6 --pitch 26 --span 80
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify WSON-6 has 6 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-05/fps.PcbLib WSON-6 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 6
+```
+
+### Step 3.4: 0402 for passives
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-05/fps.PcbLib P0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.5: 1x4 through-hole header
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-05/fps.PcbLib HDR-1X4 --description "1x4 2.54mm header"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-pad-row work/scenario-05/fps.PcbLib HDR-1X4 4 --pitch 100
+ASSERT: exit 0
+```
+
+### Step 3.6: Verify header has 4 through-hole pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-05/fps.PcbLib HDR-1X4 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 4
+```
+
+### Step 3.7: Verify library has 3 footprints
+
+```
+RUN: altium-cli pcblib list work/scenario-05/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 3
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-05/fps.PcbLib` in Altium → WSON-6.
+**Check:** 6 small SMD pads in two rows of 3, body outline visible.
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create schematic
+
+```
+RUN: altium-cli schdoc create work/scenario-05/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-component work/scenario-05/parts.SchLib TMP117 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-component work/scenario-05/parts.SchLib RES 900 1800 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-component work/scenario-05/parts.SchLib RES 1100 1800 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-component work/scenario-05/parts.SchLib CAP 1500 1200 C1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-component work/scenario-05/parts.SchLib HDR4 500 1400 J1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 5 components
+
+```
+RUN: altium-cli schdoc components work/scenario-05/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 5
+```
+
+### Step 4.4: Add power symbols
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-power VDD 1200 2100 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+### Step 4.5: Add I2C bus net labels
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-net-label SDA 900 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-net-label SCL 1100 1600"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire sensor power
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route U1.VDD @VDD"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire sensor I2C pins to bus labels
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route U1.SDA %SDA"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route U1.SCL %SCL"
+ASSERT: exit 0
+```
+
+### Step 4.8: Wire pull-up R1 between VDD and SDA
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route R1.1 @VDD"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route R1.2 %SDA"
+ASSERT: exit 0
+```
+
+### Step 4.9: Wire pull-up R2 between VDD and SCL
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route R2.1 @VDD"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route R2.2 %SCL"
+ASSERT: exit 0
+```
+
+### Step 4.10: Wire bypass cap
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route C1.1 @VDD"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route C1.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.11: Wire header to buses
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route J1.VDD @VDD"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route J1.GND @GND"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route J1.SDA %SDA"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route J1.SCL %SCL"
+ASSERT: exit 0
+```
+
+### Step 4.12: Tie ADD0 to GND (address 0x48)
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "route U1.ADD0 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.13: Add junctions
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1: Validate
+
+```
+RUN: altium-cli edit work/scenario-05/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify SDA net has 3 pins (U1.SDA, R1.2, J1.SDA)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-05/design.SchDoc --filter SDA --json
+ASSERT: exit 0
+ASSERT: json net "SDA" has >= 3 pins
+```
+
+### Step 5.3: Verify SCL net has 3 pins (U1.SCL, R2.2, J1.SCL)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-05/design.SchDoc --filter SCL --json
+ASSERT: exit 0
+ASSERT: json net "SCL" has >= 3 pins
+```
+
+### Step 5.4: Verify VDD net has 5 pins (U1.VDD, R1.1, R2.1, C1.1, J1.VDD)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-05/design.SchDoc --filter VDD --json
+ASSERT: exit 0
+ASSERT: json net "VDD" has >= 5 pins
+```
+
+### Step 5.5: BOM has 5 parts
+
+```
+RUN: altium-cli schdoc bom work/scenario-05/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 5
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-05/design.SchDoc` in Altium.
+**Check:** SDA and SCL labels appear at U1, at both pull-up resistors, and at J1. Pull-ups go to VDD rail.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-05/project.PrjPcb --name "I2C Temp Sensor"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-05/project.PrjPcb work/scenario-05/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-05/project.PrjPcb work/scenario-05/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-05/project.PrjPcb work/scenario-05/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1: Create PCB (20mm x 12mm = 787 x 472 mil)
+
+```
+RUN: altium-cli pcbdoc create work/scenario-05/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-05/board.PcbDoc 787 472
+ASSERT: exit 0
+```
+
+### Step 7.2: Rules
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-05/board.PcbDoc --metric --grid-size 10 --track-width 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-05/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-05/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.3: Add to project
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-05/project.PrjPcb work/scenario-05/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1: Dry-run
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-05/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "R1"
+ASSERT: stdout contains "R2"
+ASSERT: stdout contains "C1"
+ASSERT: stdout contains "J1"
+```
+
+### Step 8.2: Import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-05/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.3: Verify 5 components on PCB
+
+```
+RUN: altium-cli pcbdoc components work/scenario-05/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "C1"
+ASSERT: json output includes designator "J1"
+```
+
+### Step 8.4: Verify key nets
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-05/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "SDA"
+ASSERT: json output includes net "SCL"
+ASSERT: json output includes net "VDD"
+ASSERT: json output includes net "GND"
+```
+
+### MANUAL CHECKPOINT C
+
+Open `work/scenario-05/board.PcbDoc` in Altium.
+**Check:** U1 is a tiny 6-pad WSON, J1 is a through-hole 4-pin header (visible drill holes). Three 0402s for passives. Ratsnest shows SDA/SCL buses.

--- a/scenarios/06-opamp-buffer.md
+++ b/scenarios/06-opamp-buffer.md
@@ -1,0 +1,449 @@
+# Scenario 06 — Op-Amp Unity-Gain Buffer
+
+Op-amp in unity-gain (voltage follower) configuration with dual supply bypass
+caps. Tests analog component wiring, feedback connection (output wired back to
+inverting input), and +/- power supply nets.
+
+**Parts:** 4 (U1: OPA340 SOT-23-5, C1: 100nF V+ bypass, C2: 100nF V- bypass,
+R1: 100R output series resistor)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "OPA340" --package SOT-23-5
+ASSERT: exit 0
+ASSERT: stdout contains "OPA340"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "OPA340NA"
+ASSERT: exit 0
+ASSERT: stdout contains "IN+" or stdout contains "non-inverting"
+ASSERT: stdout contains "OUT"
+```
+
+**Record:** U1 = OPA340, SOT-23-5. Pins: OUT(1), VS-(2), IN+(3), IN-(4), VS+(5).
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-06/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate op-amp symbol (5 pins)
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-06/parts.SchLib OPA340 --pins "OUT,VS_NEG,IN_POS,IN_NEG,VS_POS" --description "CMOS Op-Amp"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 5 pins
+
+```
+RUN: altium-cli schlib component work/scenario-06/parts.SchLib OPA340 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 5
+```
+
+### Step 2.4: Add passive symbols (resistor + capacitor)
+
+```
+RUN: altium-cli schlib add-component work/scenario-06/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-06/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-06/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-06/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-06/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-06/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-06/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-06/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-06/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+### Step 2.5: Verify 3 components
+
+```
+RUN: altium-cli schlib info work/scenario-06/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 3
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-06/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: SOT-23-5 (3 pins one side, 2 the other)
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-06/fps.PcbLib SOT-23-5 --description "SOT-23 5-Lead"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-06/fps.PcbLib SOT-23-5 5 --pitch 38 --span 102
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify SOT-23-5 has 5 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-06/fps.PcbLib SOT-23-5 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 5
+```
+
+### Step 3.4: 0402 for passives
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-06/fps.PcbLib P0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.5: Verify
+
+```
+RUN: altium-cli pcblib list work/scenario-06/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 2
+```
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create schematic
+
+```
+RUN: altium-cli schdoc create work/scenario-06/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-component work/scenario-06/parts.SchLib OPA340 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-component work/scenario-06/parts.SchLib RES 1700 1400 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-component work/scenario-06/parts.SchLib CAP 900 1700 C1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-component work/scenario-06/parts.SchLib CAP 900 1100 C2"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 4 components
+
+```
+RUN: altium-cli schdoc components work/scenario-06/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 4
+```
+
+### Step 4.4: Power symbols for dual supply
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-power V+ 1200 2000 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-power V- 1200 800 ground up"
+ASSERT: exit 0
+```
+
+### Step 4.5: Signal net labels
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-net-label VIN 800 1400"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-net-label VOUT 2000 1400"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-net-label FB 1500 1200"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire op-amp power
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route U1.VS_POS @V+"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route U1.VS_NEG @V-"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire input
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route U1.IN_POS %VIN"
+ASSERT: exit 0
+```
+
+### Step 4.8: Wire output through series resistor
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route U1.OUT R1.1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route R1.2 %VOUT"
+ASSERT: exit 0
+```
+
+### Step 4.9: Wire feedback — output back to IN- (unity gain)
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-net-label FB 1200 1200"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route U1.OUT %FB"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route U1.IN_NEG %FB"
+ASSERT: exit 0
+```
+
+### Step 4.10: Wire bypass caps
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route C1.1 @V+"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route C1.2 @V-"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route C2.1 @V+"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "route C2.2 @V-"
+ASSERT: exit 0
+```
+
+### Step 4.11: Junctions
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1: Validate
+
+```
+RUN: altium-cli edit work/scenario-06/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify feedback net connects OUT and IN-
+
+```
+RUN: altium-cli schdoc netlist work/scenario-06/design.SchDoc --filter FB --json
+ASSERT: exit 0
+ASSERT: json net "FB" has >= 2 pins
+```
+
+### Step 5.3: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-06/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 4
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-06/design.SchDoc` in Altium.
+**Check:** Op-amp output connects back to IN- (feedback path visible). Two bypass caps between V+ and V-.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-06/project.PrjPcb --name "Op-Amp Buffer"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-06/project.PrjPcb work/scenario-06/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-06/project.PrjPcb work/scenario-06/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-06/project.PrjPcb work/scenario-06/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-06/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-06/board.PcbDoc 591 394
+ASSERT: exit 0
+```
+
+### Step 7.2: Settings and rules
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-06/board.PcbDoc --imperial --grid-size 25 --track-width 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-06/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-06/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.3: Add to project
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-06/project.PrjPcb work/scenario-06/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1: Import
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-06/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "R1"
+ASSERT: stdout contains "C1"
+ASSERT: stdout contains "C2"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-06/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2: Verify
+
+```
+RUN: altium-cli pcbdoc components work/scenario-06/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "C1"
+ASSERT: json output includes designator "C2"
+```
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-06/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "VIN"
+ASSERT: json output includes net "VOUT"
+ASSERT: json output includes net "FB"
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-06/board.PcbDoc` in Altium.
+**Check:** U1 has SOT-23-5 footprint (5 pads). Two 0402 caps and one 0402 resistor. Ratsnest shows feedback loop.

--- a/scenarios/07-mosfet-led-driver.md
+++ b/scenarios/07-mosfet-led-driver.md
@@ -1,0 +1,423 @@
+# Scenario 07 — N-Channel MOSFET LED Driver
+
+An N-channel MOSFET switches an LED on/off from a logic signal. Tests a 3-pin
+device (gate, drain, source), power switching topology, and gate pull-down
+resistor.
+
+**Parts:** 4 (Q1: 2N7002 SOT-23, R1: 330R LED limit, R2: 10k gate pull-down,
+D1: green LED 0805)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "2N7002" --package SOT-23
+ASSERT: exit 0
+ASSERT: stdout contains "2N7002"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "2N7002"
+ASSERT: exit 0
+ASSERT: stdout contains "Gate" or stdout contains "G"
+ASSERT: stdout contains "Drain" or stdout contains "D"
+```
+
+**Record:** Q1 = 2N7002, SOT-23-3. Pins: G(1), S(2), D(3). Vgs(th) ~ 2.1V.
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-07/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate MOSFET symbol (3 pins)
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-07/parts.SchLib NMOS --pins "G,S,D" --description "N-Ch MOSFET"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 3 pins
+
+```
+RUN: altium-cli schlib component work/scenario-07/parts.SchLib NMOS --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 3
+```
+
+### Step 2.4: Add resistor, LED symbols
+
+```
+RUN: altium-cli schlib add-component work/scenario-07/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-07/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-07/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-07/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-07/parts.SchLib LED --description "LED"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-07/parts.SchLib LED A "Anode" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-07/parts.SchLib LED K "Cathode" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-07/parts.SchLib LED -30 -20 30 20
+ASSERT: exit 0
+```
+
+### Step 2.5: Verify 3 symbols in library
+
+```
+RUN: altium-cli schlib info work/scenario-07/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 3
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-07/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: SOT-23-3 for MOSFET
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-07/fps.PcbLib SOT-23-3 --description "SOT-23 3-Lead"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-07/fps.PcbLib SOT-23-3 3 --pitch 38 --span 102
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify SOT-23-3 has 3 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-07/fps.PcbLib SOT-23-3 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 3
+```
+
+### Step 3.4: 0402 for resistors
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-07/fps.PcbLib R0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.5: 0805 for LED
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-07/fps.PcbLib LED0805 --size 0805
+ASSERT: exit 0
+```
+
+### Step 3.6: Verify 3 footprints
+
+```
+RUN: altium-cli pcblib list work/scenario-07/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 3
+```
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create
+
+```
+RUN: altium-cli schdoc create work/scenario-07/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-component work/scenario-07/parts.SchLib NMOS 1200 1000 Q1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-component work/scenario-07/parts.SchLib RES 1200 1600 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-component work/scenario-07/parts.SchLib RES 800 1000 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-component work/scenario-07/parts.SchLib LED 1200 1900 D1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 4 components
+
+```
+RUN: altium-cli schdoc components work/scenario-07/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 4
+```
+
+### Step 4.4: Power and signal labels
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-power VCC 1200 2200 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-power GND 1200 600 ground up"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-net-label GATE_IN 600 1000"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-net-label LED_DRIVE 1200 1400"
+ASSERT: exit 0
+```
+
+### Step 4.5: Wire LED circuit — VCC → D1.A → D1.K → R1 → MOSFET drain
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route D1.A @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route D1.K R1.1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route R1.2 %LED_DRIVE"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route Q1.D %LED_DRIVE"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire MOSFET source to GND
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route Q1.S @GND"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire gate with pull-down
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route Q1.G %GATE_IN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route R2.1 %GATE_IN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "route R2.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.8: Junctions
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1
+
+```
+RUN: altium-cli edit work/scenario-07/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify LED_DRIVE net connects R1.2 and Q1.D
+
+```
+RUN: altium-cli schdoc netlist work/scenario-07/design.SchDoc --filter LED_DRIVE --json
+ASSERT: exit 0
+ASSERT: json net "LED_DRIVE" has >= 2 pins
+```
+
+### Step 5.3: Verify GATE_IN net connects Q1.G and R2.1
+
+```
+RUN: altium-cli schdoc netlist work/scenario-07/design.SchDoc --filter GATE_IN --json
+ASSERT: exit 0
+ASSERT: json net "GATE_IN" has >= 2 pins
+```
+
+### Step 5.4: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-07/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 4
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-07/design.SchDoc` in Altium.
+**Check:** Current path is VCC → D1 → R1 → Q1 drain → Q1 source → GND. Gate has pull-down R2 to GND.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-07/project.PrjPcb --name "LED Driver"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-07/project.PrjPcb work/scenario-07/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-07/project.PrjPcb work/scenario-07/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-07/project.PrjPcb work/scenario-07/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-07/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-07/board.PcbDoc 591 394
+ASSERT: exit 0
+```
+
+### Step 7.2
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-07/board.PcbDoc --imperial --grid-size 25 --track-width 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-07/board.PcbDoc "Clearance" --value 8
+ASSERT: exit 0
+```
+
+### Step 7.3
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-07/project.PrjPcb work/scenario-07/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-07/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "Q1"
+ASSERT: stdout contains "R1"
+ASSERT: stdout contains "D1"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-07/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2
+
+```
+RUN: altium-cli pcbdoc components work/scenario-07/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "Q1"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "D1"
+```
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-07/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "GATE_IN"
+ASSERT: json output includes net "LED_DRIVE"
+ASSERT: json output includes net "VCC"
+ASSERT: json output includes net "GND"
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-07/board.PcbDoc` in Altium.
+**Check:** Q1 is SOT-23-3 (3 pads), D1 is 0805, R1 and R2 are 0402. Four distinct ratsnest clusters visible.

--- a/scenarios/08-rs485-transceiver.md
+++ b/scenarios/08-rs485-transceiver.md
@@ -1,0 +1,496 @@
+# Scenario 08 — RS-485 Transceiver
+
+RS-485 line driver IC with bus termination resistor and TVS protection diode.
+Tests differential pair net naming (A/B), multi-function IC with enable pins,
+and protection component placement.
+
+**Parts:** 5 (U1: MAX485 SOIC-8, R1: 120R termination, R2: 10k pull-up on A,
+R3: 10k pull-down on B, C1: 100nF bypass)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "MAX485" --package SOIC-8
+ASSERT: exit 0
+ASSERT: stdout contains "MAX485"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "MAX485ESA"
+ASSERT: exit 0
+ASSERT: stdout contains "RO" or stdout contains "receiver"
+ASSERT: stdout contains "DI" or stdout contains "driver"
+```
+
+**Record:** U1 = MAX485, SOIC-8. Pins: RO(1), RE(2), DE(3), DI(4), GND(5), A(6), B(7), VCC(8).
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-08/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate MAX485 symbol (8 pins)
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-08/parts.SchLib MAX485 --pins "RO,RE_N,DE,DI,GND,A,B,VCC" --description "RS-485 Transceiver"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 8 pins
+
+```
+RUN: altium-cli schlib component work/scenario-08/parts.SchLib MAX485 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 8
+```
+
+### Step 2.4: Add resistor and cap symbols
+
+```
+RUN: altium-cli schlib add-component work/scenario-08/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-08/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-08/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-08/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-08/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-08/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-08/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-08/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-08/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+### Step 2.5: Verify 3 components
+
+```
+RUN: altium-cli schlib info work/scenario-08/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 3
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-08/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: SOIC-8
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-08/fps.PcbLib SOIC-8 --description "SOIC-8"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-08/fps.PcbLib SOIC-8 8 --pitch 50 --span 244
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify SOIC-8
+
+```
+RUN: altium-cli pcblib footprint work/scenario-08/fps.PcbLib SOIC-8 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 8
+```
+
+### Step 3.4: 0402 for passives
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-08/fps.PcbLib P0402 --size 0402
+ASSERT: exit 0
+```
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create
+
+```
+RUN: altium-cli schdoc create work/scenario-08/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-component work/scenario-08/parts.SchLib MAX485 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-component work/scenario-08/parts.SchLib RES 1700 1600 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-component work/scenario-08/parts.SchLib RES 1700 1800 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-component work/scenario-08/parts.SchLib RES 1700 1200 R3"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-component work/scenario-08/parts.SchLib CAP 900 1200 C1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 5 components
+
+```
+RUN: altium-cli schdoc components work/scenario-08/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 5
+```
+
+### Step 4.4: Power and bus labels
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-power VCC 1200 2000 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-net-label RS485_A 1600 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-net-label RS485_B 1600 1200"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-net-label TX_DATA 800 1400"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-net-label RX_DATA 800 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-net-label TX_EN 800 1200"
+ASSERT: exit 0
+```
+
+### Step 4.5: Wire IC power
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.VCC @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire data lines
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.DI %TX_DATA"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.RO %RX_DATA"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire enable pins (tie DE and RE_N together for half-duplex)
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.DE %TX_EN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.RE_N %TX_EN"
+ASSERT: exit 0
+```
+
+### Step 4.8: Wire differential bus
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.A %RS485_A"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route U1.B %RS485_B"
+ASSERT: exit 0
+```
+
+### Step 4.9: Wire termination resistor across A-B
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route R1.1 %RS485_A"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route R1.2 %RS485_B"
+ASSERT: exit 0
+```
+
+### Step 4.10: Wire bias resistors (R2: A pull-up, R3: B pull-down)
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route R2.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route R2.2 %RS485_A"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route R3.1 %RS485_B"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route R3.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.11: Wire bypass cap
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route C1.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "route C1.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.12: Junctions
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1
+
+```
+RUN: altium-cli edit work/scenario-08/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify RS485_A net has 3 pins (U1.A, R1.1, R2.2)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-08/design.SchDoc --filter RS485_A --json
+ASSERT: exit 0
+ASSERT: json net "RS485_A" has >= 3 pins
+```
+
+### Step 5.3: Verify RS485_B net has 3 pins (U1.B, R1.2, R3.1)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-08/design.SchDoc --filter RS485_B --json
+ASSERT: exit 0
+ASSERT: json net "RS485_B" has >= 3 pins
+```
+
+### Step 5.4: Verify TX_EN net ties DE and RE_N together
+
+```
+RUN: altium-cli schdoc netlist work/scenario-08/design.SchDoc --filter TX_EN --json
+ASSERT: exit 0
+ASSERT: json net "TX_EN" has >= 2 pins
+```
+
+### Step 5.5: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-08/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 5
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-08/design.SchDoc` in Altium.
+**Check:** RS485_A and RS485_B labels visible on bus side. R1 bridges A-B (termination). DE and RE_N share TX_EN label.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-08/project.PrjPcb --name "RS-485 Interface"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-08/project.PrjPcb work/scenario-08/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-08/project.PrjPcb work/scenario-08/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-08/project.PrjPcb work/scenario-08/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-08/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-08/board.PcbDoc 787 394
+ASSERT: exit 0
+```
+
+### Step 7.2
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-08/board.PcbDoc --imperial --grid-size 25 --track-width 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-08/board.PcbDoc "Clearance" --value 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-08/board.PcbDoc "MinTrackWidth" --value 8
+ASSERT: exit 0
+```
+
+### Step 7.3
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-08/project.PrjPcb work/scenario-08/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-08/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-08/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2: Verify all 5 components
+
+```
+RUN: altium-cli pcbdoc components work/scenario-08/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "R3"
+ASSERT: json output includes designator "C1"
+```
+
+### Step 8.3: Verify differential pair nets
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-08/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "RS485_A"
+ASSERT: json output includes net "RS485_B"
+ASSERT: json output includes net "TX_DATA"
+ASSERT: json output includes net "RX_DATA"
+ASSERT: json output includes net "TX_EN"
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-08/board.PcbDoc` in Altium.
+**Check:** U1 is SOIC-8. Four 0402 passives. Ratsnest shows RS485_A and RS485_B nets connecting U1 to termination resistor R1.

--- a/scenarios/09-ldo-regulator.md
+++ b/scenarios/09-ldo-regulator.md
@@ -1,0 +1,466 @@
+# Scenario 09 — LDO Voltage Regulator
+
+3.3V LDO with input/output filtering and an enable pin tied through a resistor.
+Tests power-in/power-out rail naming, ceramic cap placement convention, and
+SOT-223 footprint generation.
+
+**Parts:** 4 (U1: AMS1117-3.3 SOT-223, C1: 10uF input 0805, C2: 10uF output
+0805, R1: 100k enable pull-up 0402)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "AMS1117-3.3" --package SOT-223
+ASSERT: exit 0
+ASSERT: stdout contains "AMS1117" or stdout contains "1117"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "AMS1117-3.3"
+ASSERT: exit 0
+ASSERT: stdout contains "IN" or stdout contains "input"
+ASSERT: stdout contains "OUT" or stdout contains "output"
+```
+
+**Record:** U1 = AMS1117-3.3, SOT-223. Pins: GND/ADJ(1), VOUT(2), VIN(3), TAB=VOUT. Fixed 3.3V output, 1A max.
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-09/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate LDO symbol (4 pins: VIN, VOUT, GND, EN)
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-09/parts.SchLib LDO --pins "VIN,VOUT,GND,EN" --description "3.3V LDO Regulator"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 4 pins
+
+```
+RUN: altium-cli schlib component work/scenario-09/parts.SchLib LDO --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 4
+```
+
+### Step 2.4: Add passive symbols
+
+```
+RUN: altium-cli schlib add-component work/scenario-09/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-09/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-09/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-09/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-09/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-09/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-09/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-09/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-09/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+### Step 2.5: Verify 3 library components
+
+```
+RUN: altium-cli schlib info work/scenario-09/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 3
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-09/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: SOT-223 (4 pads: 3 small + 1 tab)
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-09/fps.PcbLib SOT-223 --description "SOT-223-3"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-09/fps.PcbLib SOT-223 4 --pitch 90 --span 260
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify 4 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-09/fps.PcbLib SOT-223 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 4
+```
+
+### Step 3.4: 0805 for capacitors
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-09/fps.PcbLib C0805 --size 0805
+ASSERT: exit 0
+```
+
+### Step 3.5: 0402 for resistor
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-09/fps.PcbLib R0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.6: Verify 3 footprints
+
+```
+RUN: altium-cli pcblib list work/scenario-09/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 3
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-09/fps.PcbLib` in Altium → SOT-223.
+**Check:** 3 small pads on one side, 1 large tab pad on the other side.
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create
+
+```
+RUN: altium-cli schdoc create work/scenario-09/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-component work/scenario-09/parts.SchLib LDO 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-component work/scenario-09/parts.SchLib CAP 900 1200 C1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-component work/scenario-09/parts.SchLib CAP 1500 1200 C2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-component work/scenario-09/parts.SchLib RES 1000 1700 R1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 4 components
+
+```
+RUN: altium-cli schdoc components work/scenario-09/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 4
+```
+
+### Step 4.4: Power rails — separate input and output rail names
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-net-label VIN_5V 900 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-net-label VOUT_3V3 1500 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+### Step 4.5: Wire LDO VIN to input rail
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route U1.VIN %VIN_5V"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire LDO VOUT to output rail
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route U1.VOUT %VOUT_3V3"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire LDO GND
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+```
+
+### Step 4.8: Wire enable through pull-up to VIN
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route R1.1 %VIN_5V"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route R1.2 U1.EN"
+ASSERT: exit 0
+```
+
+### Step 4.9: Input cap on VIN rail
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route C1.1 %VIN_5V"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route C1.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.10: Output cap on VOUT rail
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route C2.1 %VOUT_3V3"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "route C2.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.11: Junctions
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1
+
+```
+RUN: altium-cli edit work/scenario-09/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: VIN_5V net should have 3 pins (U1.VIN, R1.1, C1.1)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-09/design.SchDoc --filter VIN_5V --json
+ASSERT: exit 0
+ASSERT: json net "VIN_5V" has >= 3 pins
+```
+
+### Step 5.3: VOUT_3V3 net should have 2 pins (U1.VOUT, C2.1)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-09/design.SchDoc --filter VOUT_3V3 --json
+ASSERT: exit 0
+ASSERT: json net "VOUT_3V3" has >= 2 pins
+```
+
+### Step 5.4: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-09/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 4
+```
+
+### Step 5.5: Power map
+
+```
+RUN: altium-cli schdoc power-map work/scenario-09/design.SchDoc --json
+ASSERT: exit 0
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-09/design.SchDoc` in Altium.
+**Check:** VIN_5V label on left (input) side, VOUT_3V3 on right (output) side. C1 on input, C2 on output. R1 pull-up from VIN to EN.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-09/project.PrjPcb --name "LDO Regulator"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-09/project.PrjPcb work/scenario-09/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-09/project.PrjPcb work/scenario-09/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-09/project.PrjPcb work/scenario-09/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-09/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-09/board.PcbDoc 591 394
+ASSERT: exit 0
+```
+
+### Step 7.2
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-09/board.PcbDoc --imperial --grid-size 25 --track-width 12
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-09/board.PcbDoc "Clearance" --value 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-09/board.PcbDoc "MinTrackWidth" --value 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-09/board.PcbDoc "PowerTrackWidth" --value 20
+ASSERT: exit 0
+```
+
+### Step 7.3: Verify 3 rules including power track width
+
+```
+RUN: altium-cli pcbdoc rules work/scenario-09/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json .total_rules >= 3
+```
+
+### Step 7.4
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-09/project.PrjPcb work/scenario-09/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-09/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "C1"
+ASSERT: stdout contains "C2"
+ASSERT: stdout contains "R1"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-09/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2
+
+```
+RUN: altium-cli pcbdoc components work/scenario-09/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "C1"
+ASSERT: json output includes designator "C2"
+ASSERT: json output includes designator "R1"
+```
+
+### Step 8.3: Verify power rail nets
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-09/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "VIN_5V"
+ASSERT: json output includes net "VOUT_3V3"
+ASSERT: json output includes net "GND"
+```
+
+### MANUAL CHECKPOINT C
+
+Open `work/scenario-09/board.PcbDoc` in Altium.
+**Check:** U1 is SOT-223 with tab pad. C1 and C2 are 0805. R1 is 0402. Three distinct power nets in ratsnest (VIN_5V, VOUT_3V3, GND).

--- a/scenarios/10-spi-flash.md
+++ b/scenarios/10-spi-flash.md
@@ -1,0 +1,543 @@
+# Scenario 10 — SPI Flash Breakout
+
+SPI NOR flash IC with four bus nets (MOSI, MISO, SCK, CS), pull-up on CS, bypass
+cap, and a header. Tests a 4-signal bus where one net (CS) has a different
+connection topology than the shared bus nets.
+
+**Parts:** 6 (U1: W25Q128 SOIC-8, R1: 10k CS pull-up, R2: 10k HOLD pull-up,
+C1: 100nF bypass, C2: 100nF bypass, J1: 1x6 header)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "W25Q128" --package SOIC-8
+ASSERT: exit 0
+ASSERT: stdout contains "W25Q128"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "W25Q128JVSIQ"
+ASSERT: exit 0
+ASSERT: stdout contains "CS" or stdout contains "chip select"
+ASSERT: stdout contains "CLK" or stdout contains "SCK"
+```
+
+**Record:** U1 = W25Q128, SOIC-8. Pins: CS(1), DO/MISO(2), WP(3), GND(4), DI/MOSI(5), CLK(6), HOLD(7), VCC(8).
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-10/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate W25Q128 symbol
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-10/parts.SchLib W25Q128 --pins "CS_N,MISO,WP_N,GND,MOSI,SCK,HOLD_N,VCC" --description "128Mbit SPI Flash"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 8 pins
+
+```
+RUN: altium-cli schlib component work/scenario-10/parts.SchLib W25Q128 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 8
+```
+
+### Step 2.4: Add passive and header symbols
+
+```
+RUN: altium-cli schlib add-component work/scenario-10/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-10/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-10/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-10/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-10/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-10/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-10/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-10/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-10/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-10/parts.SchLib HDR6 --pins "VCC,GND,MOSI,MISO,SCK,CS" --description "1x6 SPI Header"
+ASSERT: exit 0
+```
+
+### Step 2.5: Verify 4 components in library
+
+```
+RUN: altium-cli schlib info work/scenario-10/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 4
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-10/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: SOIC-8
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-10/fps.PcbLib SOIC-8 --description "SOIC-8"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-10/fps.PcbLib SOIC-8 8 --pitch 50 --span 244
+ASSERT: exit 0
+```
+
+### Step 3.3: 0402
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-10/fps.PcbLib P0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.4: 1x6 header
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-10/fps.PcbLib HDR-1X6 --description "1x6 header"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-pad-row work/scenario-10/fps.PcbLib HDR-1X6 6 --pitch 100
+ASSERT: exit 0
+```
+
+### Step 3.5: Verify 3 footprints
+
+```
+RUN: altium-cli pcblib list work/scenario-10/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 3
+```
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create
+
+```
+RUN: altium-cli schdoc create work/scenario-10/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-component work/scenario-10/parts.SchLib W25Q128 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-component work/scenario-10/parts.SchLib RES 1500 1800 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-component work/scenario-10/parts.SchLib RES 1500 1600 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-component work/scenario-10/parts.SchLib CAP 900 1200 C1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-component work/scenario-10/parts.SchLib CAP 900 1000 C2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-component work/scenario-10/parts.SchLib HDR6 500 1400 J1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 6 components
+
+```
+RUN: altium-cli schdoc components work/scenario-10/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 6
+```
+
+### Step 4.4: Power and SPI bus labels
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-power VCC 1200 2000 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-net-label SPI_MOSI 800 1500"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-net-label SPI_MISO 800 1300"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-net-label SPI_SCK 800 1100"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-net-label SPI_CS_N 1400 1800"
+ASSERT: exit 0
+```
+
+### Step 4.5: Wire flash IC power
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.VCC @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+```
+
+### Step 4.6: Wire SPI bus
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.MOSI %SPI_MOSI"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.MISO %SPI_MISO"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.SCK %SPI_SCK"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.CS_N %SPI_CS_N"
+ASSERT: exit 0
+```
+
+### Step 4.7: CS pull-up to VCC
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route R1.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route R1.2 %SPI_CS_N"
+ASSERT: exit 0
+```
+
+### Step 4.8: HOLD pull-up to VCC (keep flash out of hold state)
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route R2.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route R2.2 U1.HOLD_N"
+ASSERT: exit 0
+```
+
+### Step 4.9: Tie WP to VCC (disable write protect)
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route U1.WP_N @VCC"
+ASSERT: exit 0
+```
+
+### Step 4.10: Bypass caps
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route C1.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route C1.2 @GND"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route C2.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route C2.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.11: Wire header to SPI bus
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route J1.VCC @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route J1.GND @GND"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route J1.MOSI %SPI_MOSI"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route J1.MISO %SPI_MISO"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route J1.SCK %SPI_SCK"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "route J1.CS %SPI_CS_N"
+ASSERT: exit 0
+```
+
+### Step 4.12: Junctions
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1
+
+```
+RUN: altium-cli edit work/scenario-10/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify SPI bus nets each have 2 pins (U1 + J1)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-10/design.SchDoc --filter SPI_MOSI --json
+ASSERT: exit 0
+ASSERT: json net "SPI_MOSI" has >= 2 pins
+```
+
+```
+RUN: altium-cli schdoc netlist work/scenario-10/design.SchDoc --filter SPI_MISO --json
+ASSERT: exit 0
+ASSERT: json net "SPI_MISO" has >= 2 pins
+```
+
+```
+RUN: altium-cli schdoc netlist work/scenario-10/design.SchDoc --filter SPI_SCK --json
+ASSERT: exit 0
+ASSERT: json net "SPI_SCK" has >= 2 pins
+```
+
+### Step 5.3: CS net has 3 pins (U1.CS_N, R1.2, J1.CS)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-10/design.SchDoc --filter SPI_CS_N --json
+ASSERT: exit 0
+ASSERT: json net "SPI_CS_N" has >= 3 pins
+```
+
+### Step 5.4: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-10/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 6
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-10/design.SchDoc` in Altium.
+**Check:** Four SPI bus labels (MOSI, MISO, SCK, CS_N) connecting U1 to J1. R1 pull-up on CS_N. R2 pull-up on HOLD_N. WP_N tied to VCC.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-10/project.PrjPcb --name "SPI Flash Breakout"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-10/project.PrjPcb work/scenario-10/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-10/project.PrjPcb work/scenario-10/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-10/project.PrjPcb work/scenario-10/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-10/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-10/board.PcbDoc 787 472
+ASSERT: exit 0
+```
+
+### Step 7.2
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-10/board.PcbDoc --imperial --grid-size 25 --track-width 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-10/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-10/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.3
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-10/project.PrjPcb work/scenario-10/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-10/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "J1"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-10/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2: Verify all 6 components
+
+```
+RUN: altium-cli pcbdoc components work/scenario-10/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "C1"
+ASSERT: json output includes designator "C2"
+ASSERT: json output includes designator "J1"
+```
+
+### Step 8.3: Verify SPI nets
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-10/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "SPI_MOSI"
+ASSERT: json output includes net "SPI_MISO"
+ASSERT: json output includes net "SPI_SCK"
+ASSERT: json output includes net "SPI_CS_N"
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-10/board.PcbDoc` in Altium.
+**Check:** U1 is SOIC-8. J1 is through-hole 6-pin header (drill holes visible). Four 0402 passives. Ratsnest shows 4 SPI bus connections between U1 and J1.

--- a/scenarios/11-dual-opamp.md
+++ b/scenarios/11-dual-opamp.md
@@ -1,0 +1,575 @@
+# Scenario 11 — Dual Op-Amp Cascaded Gain Stages
+
+Two inverting amplifier stages built from a single dual op-amp IC. Tests the
+largest component count (8 parts), cascaded signal path (output of stage 1 feeds
+input of stage 2), and shared power supply across both op-amp sections.
+
+**Parts:** 8 (U1: LM358 SOIC-8, R1-R2: stage 1 gain network, R3-R4: stage 2
+gain network, C1: AC coupling between stages, C2: input AC coupling,
+C3: bypass cap)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "LM358" --package SOIC-8
+ASSERT: exit 0
+ASSERT: stdout contains "LM358"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "LM358DR"
+ASSERT: exit 0
+ASSERT: stdout contains "OUT" or stdout contains "output"
+```
+
+**Record:** U1 = LM358, SOIC-8. Pins: OUT1(1), IN1-(2), IN1+(3), GND(4), IN2+(5), IN2-(6), OUT2(7), VCC(8). Dual op-amp, single-supply.
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-11/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate LM358 symbol (8 pins)
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-11/parts.SchLib LM358 --pins "OUT1,IN1_NEG,IN1_POS,GND,IN2_POS,IN2_NEG,OUT2,VCC" --description "Dual Op-Amp"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 8 pins
+
+```
+RUN: altium-cli schlib component work/scenario-11/parts.SchLib LM358 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 8
+```
+
+### Step 2.4: Add passive symbols
+
+```
+RUN: altium-cli schlib add-component work/scenario-11/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-11/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-11/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-11/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-11/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-11/parts.SchLib CAP 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-11/parts.SchLib CAP 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-11/parts.SchLib CAP -10 -20 -10 20
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-11/parts.SchLib CAP 10 -20 10 20
+ASSERT: exit 0
+```
+
+### Step 2.5: Verify 3 components
+
+```
+RUN: altium-cli schlib info work/scenario-11/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 3
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-11/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: SOIC-8 for LM358
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-11/fps.PcbLib SOIC-8 --description "SOIC-8"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-11/fps.PcbLib SOIC-8 8 --pitch 50 --span 244
+ASSERT: exit 0
+```
+
+### Step 3.3: 0402 for resistors
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-11/fps.PcbLib R0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.4: 0603 for coupling caps (slightly larger for audio)
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-11/fps.PcbLib C0603 --size 0603
+ASSERT: exit 0
+```
+
+### Step 3.5: Verify 3 footprints
+
+```
+RUN: altium-cli pcblib list work/scenario-11/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 3
+```
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create
+
+```
+RUN: altium-cli schdoc create work/scenario-11/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place all 8 components
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib LM358 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib CAP 700 1400 C2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib RES 900 1400 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib RES 1100 1700 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib CAP 1500 1400 C1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib RES 1700 1400 R3"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib RES 1900 1700 R4"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-component work/scenario-11/parts.SchLib CAP 1000 1100 C3"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 8 components
+
+```
+RUN: altium-cli schdoc components work/scenario-11/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 8
+```
+
+### Step 4.4: Power and signal labels
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-power VCC 1200 2000 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label AUDIO_IN 600 1400"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label STAGE1_IN 900 1300"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label STAGE1_OUT 1400 1400"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label STAGE1_FB 1100 1600"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label STAGE2_IN 1700 1300"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label STAGE2_OUT 2100 1400"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-net-label STAGE2_FB 1900 1600"
+ASSERT: exit 0
+```
+
+### Step 4.5: Wire IC power
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.VCC @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+```
+
+### Step 4.6: Stage 1 — inverting amplifier on op-amp section 1
+
+Input AC coupling: AUDIO_IN → C2 → R1 → IN1_NEG
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route C2.1 %AUDIO_IN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route C2.2 %STAGE1_IN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R1.1 %STAGE1_IN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R1.2 U1.IN1_NEG"
+ASSERT: exit 0
+```
+
+Non-inverting input to GND (AC ground):
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.IN1_POS @GND"
+ASSERT: exit 0
+```
+
+Feedback resistor R2 from OUT1 back to IN1_NEG:
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.OUT1 %STAGE1_OUT"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R2.1 %STAGE1_FB"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R2.2 %STAGE1_OUT"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.IN1_NEG %STAGE1_FB"
+ASSERT: exit 0
+```
+
+### Step 4.7: Inter-stage AC coupling
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route C1.1 %STAGE1_OUT"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route C1.2 %STAGE2_IN"
+ASSERT: exit 0
+```
+
+### Step 4.8: Stage 2 — inverting amplifier on op-amp section 2
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R3.1 %STAGE2_IN"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R3.2 U1.IN2_NEG"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.IN2_POS @GND"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.OUT2 %STAGE2_OUT"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R4.1 %STAGE2_FB"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route R4.2 %STAGE2_OUT"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route U1.IN2_NEG %STAGE2_FB"
+ASSERT: exit 0
+```
+
+### Step 4.9: Bypass cap
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route C3.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "route C3.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.10: Junctions
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1
+
+```
+RUN: altium-cli edit work/scenario-11/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify inter-stage coupling — STAGE1_OUT connects OUT1 and C1 and R2
+
+```
+RUN: altium-cli schdoc netlist work/scenario-11/design.SchDoc --filter STAGE1_OUT --json
+ASSERT: exit 0
+ASSERT: json net "STAGE1_OUT" has >= 3 pins
+```
+
+### Step 5.3: Verify stage 2 output
+
+```
+RUN: altium-cli schdoc netlist work/scenario-11/design.SchDoc --filter STAGE2_OUT --json
+ASSERT: exit 0
+ASSERT: json net "STAGE2_OUT" has >= 2 pins
+```
+
+### Step 5.4: Total net count (expect ~10: VCC, GND, AUDIO_IN, STAGE1_IN, STAGE1_OUT, STAGE1_FB, STAGE2_IN, STAGE2_OUT, STAGE2_FB, plus internal)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-11/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_nets >= 8
+```
+
+### Step 5.5: BOM
+
+```
+RUN: altium-cli schdoc bom work/scenario-11/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 8
+```
+
+### Step 5.6: Signal flow from AUDIO_IN through stages
+
+```
+RUN: altium-cli schdoc signal-flow work/scenario-11/design.SchDoc AUDIO_IN
+ASSERT: exit 0
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-11/design.SchDoc` in Altium.
+**Check:** Two distinct amplifier stages visible. C1 couples STAGE1_OUT to STAGE2_IN. Each stage has a feedback resistor (R2, R4) from output to inverting input.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-11/project.PrjPcb --name "Dual Op-Amp Gain"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-11/project.PrjPcb work/scenario-11/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-11/project.PrjPcb work/scenario-11/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-11/project.PrjPcb work/scenario-11/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-11/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-11/board.PcbDoc 984 591
+ASSERT: exit 0
+```
+
+### Step 7.2
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-11/board.PcbDoc --imperial --grid-size 25 --track-width 8
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-11/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-11/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+### Step 7.3
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-11/project.PrjPcb work/scenario-11/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-11/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "R1"
+ASSERT: stdout contains "R2"
+ASSERT: stdout contains "R3"
+ASSERT: stdout contains "R4"
+ASSERT: stdout contains "C1"
+ASSERT: stdout contains "C2"
+ASSERT: stdout contains "C3"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-11/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2: Verify all 8 components
+
+```
+RUN: altium-cli pcbdoc components work/scenario-11/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "R3"
+ASSERT: json output includes designator "R4"
+ASSERT: json output includes designator "C1"
+ASSERT: json output includes designator "C2"
+ASSERT: json output includes designator "C3"
+```
+
+### Step 8.3: Verify signal-path nets
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-11/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "AUDIO_IN"
+ASSERT: json output includes net "STAGE1_OUT"
+ASSERT: json output includes net "STAGE2_OUT"
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-11/board.PcbDoc` in Altium.
+**Check:** U1 is SOIC-8. 4x 0402 resistors and 3x 0603 capacitors. Ratsnest shows signal chain flowing through C2 → R1 → U1 → C1 → R3 → U1 → output.

--- a/scenarios/12-current-sensor.md
+++ b/scenarios/12-current-sensor.md
@@ -1,0 +1,626 @@
+# Scenario 12 — INA219 Current Sensor
+
+INA219 high-side current sensor with shunt resistor, I2C bus, and bypass cap.
+Tests precision analog + digital mixed design, Kelvin-sense net topology (shunt
+resistor has 4 nets: 2 high-current + 2 sense), and I2C address configuration.
+
+**Parts:** 6 (U1: INA219 MSOP-8, R_SHUNT: 100mR 2512, R1: 4.7k SDA pull-up,
+R2: 4.7k SCL pull-up, C1: 100nF bypass, J1: 1x4 I2C header)
+
+---
+
+## Phase 1 — Part Selection
+
+### Step 1.1
+
+```
+RUN: datasheet-cli search "INA219" --package MSOP-8
+ASSERT: exit 0
+ASSERT: stdout contains "INA219"
+```
+
+### Step 1.2
+
+```
+RUN: datasheet-cli pinout "INA219AIDR"
+ASSERT: exit 0
+ASSERT: stdout contains "IN+" or stdout contains "VIN"
+ASSERT: stdout contains "SDA"
+```
+
+**Record:** U1 = INA219, MSOP-8. Pins: A1(1), A0(2), SDA(3), SCL(4), GND(5), VS(6), IN-(7), IN+(8). I2C address set by A0/A1.
+
+---
+
+## Phase 2 — Schematic Library
+
+### Step 2.1: Create
+
+```
+RUN: altium-cli schlib create work/scenario-12/parts.SchLib
+ASSERT: exit 0
+```
+
+### Step 2.2: Generate INA219 symbol (8 pins)
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-12/parts.SchLib INA219 --pins "A1,A0,SDA,SCL,GND,VS,INM,INP" --description "I2C Current/Power Monitor"
+ASSERT: exit 0
+```
+
+### Step 2.3: Verify 8 pins
+
+```
+RUN: altium-cli schlib component work/scenario-12/parts.SchLib INA219 --json
+ASSERT: exit 0
+ASSERT: json .pin_count == 8
+```
+
+### Step 2.4: Add passive symbols
+
+```
+RUN: altium-cli schlib add-component work/scenario-12/parts.SchLib RES --description "Resistor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-12/parts.SchLib RES 1 "1" -50 0 --direction right --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-12/parts.SchLib RES 2 "2" 50 0 --direction left --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-rectangle work/scenario-12/parts.SchLib RES -30 -10 30 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-component work/scenario-12/parts.SchLib CAP --description "Capacitor"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-12/parts.SchLib CAP 1 "1" 0 50 --direction down --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-pin work/scenario-12/parts.SchLib CAP 2 "2" 0 -50 --direction up --electrical passive
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-12/parts.SchLib CAP -20 10 20 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli schlib add-line work/scenario-12/parts.SchLib CAP -20 -10 20 -10
+ASSERT: exit 0
+```
+
+### Step 2.5: Generate 1x4 header
+
+```
+RUN: altium-cli schlib gen-ic work/scenario-12/parts.SchLib HDR4 --pins "VCC,GND,SDA,SCL" --description "1x4 I2C Header"
+ASSERT: exit 0
+```
+
+### Step 2.6: Verify 4 library components
+
+```
+RUN: altium-cli schlib info work/scenario-12/parts.SchLib --json
+ASSERT: exit 0
+ASSERT: json .component_count == 4
+```
+
+---
+
+## Phase 3 — Footprint Library
+
+### Step 3.1: Create
+
+```
+RUN: altium-cli pcblib create work/scenario-12/fps.PcbLib
+ASSERT: exit 0
+```
+
+### Step 3.2: MSOP-8 for INA219
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-12/fps.PcbLib MSOP-8 --description "MSOP-8 3x3mm"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-dual-row work/scenario-12/fps.PcbLib MSOP-8 8 --pitch 26 --span 197
+ASSERT: exit 0
+```
+
+### Step 3.3: Verify MSOP-8 has 8 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-12/fps.PcbLib MSOP-8 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 8
+```
+
+### Step 3.4: 2512 for shunt resistor (large current-handling package)
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-12/fps.PcbLib R2512 --size 2512
+ASSERT: exit 0
+```
+
+### Step 3.5: Verify 2512 has 2 pads
+
+```
+RUN: altium-cli pcblib footprint work/scenario-12/fps.PcbLib R2512 --json
+ASSERT: exit 0
+ASSERT: json .pad_count == 2
+```
+
+### Step 3.6: Verify 2512 is larger than 0402
+
+```
+RUN: altium-cli pcblib measure work/scenario-12/fps.PcbLib R2512 --json
+ASSERT: exit 0
+ASSERT: json .dimensions.width.mils > 100
+```
+
+### Step 3.7: 0402 for pull-ups and bypass
+
+```
+RUN: altium-cli pcblib gen-chip work/scenario-12/fps.PcbLib P0402 --size 0402
+ASSERT: exit 0
+```
+
+### Step 3.8: 1x4 header
+
+```
+RUN: altium-cli pcblib add-footprint work/scenario-12/fps.PcbLib HDR-1X4 --description "1x4 header"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcblib add-pad-row work/scenario-12/fps.PcbLib HDR-1X4 4 --pitch 100
+ASSERT: exit 0
+```
+
+### Step 3.9: Verify 4 footprints
+
+```
+RUN: altium-cli pcblib list work/scenario-12/fps.PcbLib --json
+ASSERT: exit 0
+ASSERT: json .total_footprints == 4
+```
+
+### MANUAL CHECKPOINT A
+
+Open `work/scenario-12/fps.PcbLib` in Altium → R2512.
+**Check:** Two large pads — visibly bigger than P0402 footprint. This is the power shunt.
+
+---
+
+## Phase 4 — Schematic Entry
+
+### Step 4.1: Create
+
+```
+RUN: altium-cli schdoc create work/scenario-12/design.SchDoc
+ASSERT: exit 0
+```
+
+### Step 4.2: Place components
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-component work/scenario-12/parts.SchLib INA219 1200 1400 U1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-component work/scenario-12/parts.SchLib RES 1200 1900 R_SHUNT"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-component work/scenario-12/parts.SchLib RES 800 1700 R1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-component work/scenario-12/parts.SchLib RES 1000 1700 R2"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-component work/scenario-12/parts.SchLib CAP 1500 1200 C1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-component work/scenario-12/parts.SchLib HDR4 500 1400 J1"
+ASSERT: exit 0
+```
+
+### Step 4.3: Verify 6 components
+
+```
+RUN: altium-cli schdoc components work/scenario-12/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 6
+```
+
+### Step 4.4: Power and bus labels
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-power VCC 1200 2200 bar down"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-power GND 1200 800 ground up"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-net-label SDA 800 1500"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-net-label SCL 1000 1500"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-net-label SENSE_P 1100 1900"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-net-label SENSE_N 1300 1900"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-net-label LOAD_IN 900 2000"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-net-label LOAD_OUT 1500 2000"
+ASSERT: exit 0
+```
+
+### Step 4.5: Wire shunt resistor in the high-side current path
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R_SHUNT.1 %SENSE_P"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R_SHUNT.2 %SENSE_N"
+ASSERT: exit 0
+```
+
+### Step 4.6: Connect current path through shunt
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route %LOAD_IN R_SHUNT.1"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R_SHUNT.2 %LOAD_OUT"
+ASSERT: exit 0
+```
+
+### Step 4.7: Wire INA219 sense inputs to shunt
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.INP %SENSE_P"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.INM %SENSE_N"
+ASSERT: exit 0
+```
+
+### Step 4.8: Wire INA219 power and bus supply
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.VS @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.GND @GND"
+ASSERT: exit 0
+```
+
+### Step 4.9: Wire I2C bus
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.SDA %SDA"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.SCL %SCL"
+ASSERT: exit 0
+```
+
+### Step 4.10: I2C pull-ups
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R1.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R1.2 %SDA"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R2.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route R2.2 %SCL"
+ASSERT: exit 0
+```
+
+### Step 4.11: Address config — A0 and A1 to GND (address 0x40)
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.A0 @GND"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route U1.A1 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.12: Bypass cap
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route C1.1 @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route C1.2 @GND"
+ASSERT: exit 0
+```
+
+### Step 4.13: Header
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route J1.VCC @VCC"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route J1.GND @GND"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route J1.SDA %SDA"
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "route J1.SCL %SCL"
+ASSERT: exit 0
+```
+
+### Step 4.14: Junctions
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "add-missing-junctions"
+ASSERT: exit 0
+```
+
+---
+
+## Phase 5 — Validation
+
+### Step 5.1
+
+```
+RUN: altium-cli edit work/scenario-12/design.SchDoc -c "validate"
+ASSERT: exit 0
+```
+
+### Step 5.2: Verify SENSE_P net has 2 pins (R_SHUNT.1, U1.INP)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-12/design.SchDoc --filter SENSE_P --json
+ASSERT: exit 0
+ASSERT: json net "SENSE_P" has >= 2 pins
+```
+
+### Step 5.3: Verify SENSE_N net has 2 pins (R_SHUNT.2, U1.INM)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-12/design.SchDoc --filter SENSE_N --json
+ASSERT: exit 0
+ASSERT: json net "SENSE_N" has >= 2 pins
+```
+
+### Step 5.4: Verify I2C bus nets
+
+```
+RUN: altium-cli schdoc netlist work/scenario-12/design.SchDoc --filter SDA --json
+ASSERT: exit 0
+ASSERT: json net "SDA" has >= 3 pins
+```
+
+```
+RUN: altium-cli schdoc netlist work/scenario-12/design.SchDoc --filter SCL --json
+ASSERT: exit 0
+ASSERT: json net "SCL" has >= 3 pins
+```
+
+### Step 5.5: BOM has 6 parts
+
+```
+RUN: altium-cli schdoc bom work/scenario-12/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_components == 6
+```
+
+### Step 5.6: Total nets should be ~8+ (VCC, GND, SDA, SCL, SENSE_P, SENSE_N, LOAD_IN, LOAD_OUT)
+
+```
+RUN: altium-cli schdoc netlist work/scenario-12/design.SchDoc --json
+ASSERT: exit 0
+ASSERT: json .total_nets >= 8
+```
+
+### MANUAL CHECKPOINT B
+
+Open `work/scenario-12/design.SchDoc` in Altium.
+**Check:** Shunt resistor R_SHUNT sits in the high-side current path (LOAD_IN → R_SHUNT → LOAD_OUT). INA219 sense inputs (INP/INM) tap both sides of the shunt via SENSE_P/SENSE_N labels. I2C bus with pull-ups goes to header.
+
+---
+
+## Phase 6 — Project
+
+### Step 6.1
+
+```
+RUN: altium-cli prjpcb create work/scenario-12/project.PrjPcb --name "Current Sensor"
+ASSERT: exit 0
+```
+
+### Step 6.2
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-12/project.PrjPcb work/scenario-12/design.SchDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-12/project.PrjPcb work/scenario-12/parts.SchLib
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-12/project.PrjPcb work/scenario-12/fps.PcbLib
+ASSERT: exit 0
+```
+
+---
+
+## Phase 7 — PCB Setup
+
+### Step 7.1
+
+```
+RUN: altium-cli pcbdoc create work/scenario-12/board.PcbDoc
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc set-outline-rect work/scenario-12/board.PcbDoc 787 591
+ASSERT: exit 0
+```
+
+### Step 7.2
+
+```
+RUN: altium-cli pcbdoc set-settings work/scenario-12/board.PcbDoc --imperial --grid-size 25 --track-width 10
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-12/board.PcbDoc "Clearance" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-12/board.PcbDoc "MinTrackWidth" --value 6
+ASSERT: exit 0
+```
+
+```
+RUN: altium-cli pcbdoc add-rule work/scenario-12/board.PcbDoc "PowerTrackWidth" --value 25
+ASSERT: exit 0
+```
+
+### Step 7.3: Verify power track rule exists
+
+```
+RUN: altium-cli pcbdoc rules work/scenario-12/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json .total_rules >= 3
+```
+
+### Step 7.4
+
+```
+RUN: altium-cli prjpcb add-document work/scenario-12/project.PrjPcb work/scenario-12/board.PcbDoc
+ASSERT: exit 0
+```
+
+---
+
+## Phase 8 — Import
+
+### Step 8.1
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-12/project.PrjPcb --dry-run
+ASSERT: exit 0
+ASSERT: stdout contains "U1"
+ASSERT: stdout contains "R_SHUNT"
+ASSERT: stdout contains "J1"
+```
+
+```
+RUN: altium-cli prjpcb import-to-pcb work/scenario-12/project.PrjPcb
+ASSERT: exit 0
+```
+
+### Step 8.2: Verify all 6 components
+
+```
+RUN: altium-cli pcbdoc components work/scenario-12/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes designator "U1"
+ASSERT: json output includes designator "R_SHUNT"
+ASSERT: json output includes designator "R1"
+ASSERT: json output includes designator "R2"
+ASSERT: json output includes designator "C1"
+ASSERT: json output includes designator "J1"
+```
+
+### Step 8.3: Verify sense and bus nets
+
+```
+RUN: altium-cli pcbdoc nets work/scenario-12/board.PcbDoc --json
+ASSERT: exit 0
+ASSERT: json output includes net "SENSE_P"
+ASSERT: json output includes net "SENSE_N"
+ASSERT: json output includes net "SDA"
+ASSERT: json output includes net "SCL"
+ASSERT: json output includes net "LOAD_IN"
+ASSERT: json output includes net "LOAD_OUT"
+```
+
+### MANUAL CHECKPOINT C
+
+Open `work/scenario-12/board.PcbDoc` in Altium.
+**Check:** R_SHUNT has large 2512 pads (power path). U1 is MSOP-8 (small pads). J1 is through-hole header. Ratsnest shows SENSE_P/SENSE_N Kelvin connections from shunt to INA219. I2C bus ratsnest connects U1 to J1.

--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -1,0 +1,62 @@
+# altium-cli End-to-End Test Scenarios
+
+Twelve scenarios that exercise the full pipeline:
+
+```
+datasheet-cli (part selection)
+  → schlib create + gen-ic / add-component (schematic symbols)
+    → pcblib create + gen-chip / add-dual-row (footprints)
+      → schdoc create + edit (schematic entry + wiring)
+        → edit validate (ERC)
+          → prjpcb create + add-document (project)
+            → pcbdoc create + set-outline-rect + add-rule (board setup)
+              → prjpcb import-to-pcb (transfer to PCB)
+```
+
+Placement and routing are done **manually** after the final step.
+
+## How to read a scenario
+
+Each step has three parts:
+
+1. **`RUN:`** — the exact shell command to execute
+2. **`ASSERT:`** — conditions the agent checks on stdout/exit code
+   - `exit 0` — process exits successfully
+   - `stdout contains "X"` — substring match on stdout
+   - `json .field == value` — parse `--json` output, check a field
+   - `json .field includes "X"` — array/string membership check
+   - `file exists path` — file was created
+3. **`MANUAL CHECKPOINT:`** — (rare) operator opens a file in Altium and checks
+   one specific visual property. Always written as a single sentence.
+
+If an assertion fails, the agent should report:
+```
+FAIL scenario 03 step 4.2: expected json .pin_count == 6, got 4
+  command: altium-cli schlib component parts.SchLib TMP117 --json
+  stdout: { "name": "TMP117", "pin_count": 4, ... }
+```
+
+## Scenario index
+
+| # | Name | Parts | Key features tested |
+|---|------|-------|---------------------|
+| 01 | [Single resistor](01-single-resistor.md) | 1 | Bare-minimum pipeline, gen-chip 0402 |
+| 02 | [LED + resistor](02-led-resistor.md) | 2 | Direct wire routing between two components |
+| 03 | [MCU power-on](03-mcu-power.md) | 2 | gen-ic, power ports (VCC/GND), bypass cap |
+| 04 | [Voltage divider](04-voltage-divider.md) | 3 | Net labels, multiple nets, output tap |
+| 05 | [I2C temp sensor](05-i2c-temp-sensor.md) | 5 | I2C pull-ups, bus net labels, header |
+| 06 | [Op-amp buffer](06-opamp-buffer.md) | 4 | Analog pins, feedback wire, +/- supply |
+| 07 | [MOSFET LED driver](07-mosfet-led-driver.md) | 4 | 3-pin device, gate drive, power switching |
+| 08 | [RS-485 transceiver](08-rs485-transceiver.md) | 5 | Differential pair nets, bus termination |
+| 09 | [LDO regulator](09-ldo-regulator.md) | 4 | Power input/output rails, enable logic |
+| 10 | [SPI flash](10-spi-flash.md) | 6 | SPI bus (4 nets), chip select, pull-ups |
+| 11 | [Dual op-amp gain stages](11-dual-opamp.md) | 8 | Multi-section IC, cascaded signal path |
+| 12 | [INA219 current sensor](12-current-sensor.md) | 6 | Shunt resistor, I2C, mixed analog/digital |
+
+## Conventions
+
+- All coordinates in **mils**
+- Component spacing: ICs 400 mil apart, passives 200 mil apart
+- Schematic grid: 50 mil
+- PCB grid: 25 mil
+- Every scenario creates files in a fresh subdirectory: `work/scenario-NN/`


### PR DESCRIPTION
Each scenario exercises the complete pipeline: datasheet-cli part selection →
schematic library creation → PCB footprint library → schematic entry and wiring →
validation → project setup → PCB board setup → schematic-to-PCB import.

Every step has exact CLI commands with machine-checkable assertions (exit codes,
stdout substring matches, JSON field checks) so an agent can pinpoint failures
precisely. Manual verification checkpoints are minimal and specific (one file,
one visual check).

Scenarios range from 1-component (scenario 01: single resistor) to 8-component
(scenario 11: dual op-amp cascaded gain stages), covering: gen-ic, gen-chip,
add-dual-row, add-pad-row, power ports, net labels, direct routing, I2C/SPI
buses, feedback loops, differential pairs, mixed SMD/TH footprints, and
multi-rail power designs.

https://claude.ai/code/session_01FqfoKpnGdfdx7PhzwPNrNW